### PR TITLE
Update version to match distribution

### DIFF
--- a/hatch_nodejs_version/_version.py
+++ b/hatch_nodejs_version/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Angus Hollands <goosey15@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1"
+__version__ = "0.1.0"


### PR DESCRIPTION
Was looking to package this for conda-forge to support eventual use downstream on `jupyterlab-markup`, and as it's packaging-related, figured I'd check the version numbers.

This updates the version so that `pip list` and `import hatch_nodejs_version; hatch_nodejs_version.__version__` match.

I guess even though this can't be fixed retroactively, it's just to raise awareness. As I'm unfamiliar with `pdm` _and_ `hatch` standards (and don't really care to be), I don't know what the correct play is to keep these in sync without yet _another_ plugin.