### PR TITLE
Add a trailing newline to package.json when appropriate

### DIFF
--- a/hatch_nodejs_version/version_source.py
+++ b/hatch_nodejs_version/version_source.py
@@ -156,9 +156,16 @@ class NodeJSVersionSource(VersionSourceInterface):
         if not os.path.isfile(path):
             raise OSError(f"file does not exist: {self.path}")
 
+        # Read the original file so we can see if it has a trailing
+        # newline character.
+        with open(path, "r") as f:
+            raw_data = f.read()
+
         with open(path, "r") as f:
             data = json.load(f)
 
         data["version"] = self.python_version_to_node(version)
         with open(path, "w") as f:
             json.dump(data, f, indent=4)
+            if raw_data.endswith('\n'):
+                f.write('\n')


### PR DESCRIPTION
This was causing failures in [maintainer-tools](https://github.com/jupyterlab/maintainer-tools/actions/runs/3461099712/jobs/5778290066), which uses the `end-of-file-fixer` pre-commit hook.

Npm and Yarn also typically add a newline character to the file when interacting with it.