### PR TITLE
DOCS: drop installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This package provides two Hatch plugins:
 
 **Table of Contents**
 
-- [Installation](#installation)
 - [Global dependency](#global-dependency)
 - [Version source](#version-source)
 - [Metadata hook](#metadata-hook)


### PR DESCRIPTION
The link in the README to the installation section is no longer valid.